### PR TITLE
Feat/set operator

### DIFF
--- a/contracts/oraiswap_factory/src/state.rs
+++ b/contracts/oraiswap_factory/src/state.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub token_code_id: u64,
     pub commission_rate: String,
     pub operator_fee: String,
+    pub operator: CanonicalAddr,
 }
 
 // put the length bytes at the first for compatibility with legacy singleton store
@@ -89,6 +90,7 @@ mod test {
                 token_code_id: 1,
                 commission_rate: DEFAULT_COMMISSION_RATE.to_string(),
                 operator_fee: DEFAULT_OPERATOR_FEE.to_string(),
+                operator: deps.api.addr_canonicalize("operator").unwrap(),
             },
         )
         .unwrap();

--- a/contracts/oraiswap_factory/src/testing.rs
+++ b/contracts/oraiswap_factory/src/testing.rs
@@ -1,8 +1,9 @@
-use cosmwasm_std::Addr;
+use cosmwasm_std::{to_json_binary, Addr};
 use oraiswap::asset::{AssetInfo, PairInfo};
 
 use oraiswap::create_entry_points_testing;
-use oraiswap::pair::{DEFAULT_COMMISSION_RATE, DEFAULT_OPERATOR_FEE};
+use oraiswap::factory::ConfigResponse;
+use oraiswap::pair::{PairResponse, DEFAULT_COMMISSION_RATE, DEFAULT_OPERATOR_FEE};
 use oraiswap::querier::query_pair_info_from_pair;
 use oraiswap::testing::MockApp;
 
@@ -47,6 +48,24 @@ fn create_pair() {
     // query pair info
     let pair_info =
         query_pair_info_from_pair(&app.as_querier().into_empty(), contract_addr.clone()).unwrap();
+
+    // get config
+    let config: String = app
+        .as_querier()
+        .query_wasm_smart(
+            contract_addr.clone(),
+            &oraiswap::pair::QueryMsg::Operator {},
+        )
+        .unwrap();
+
+    let factory_config: ConfigResponse = app
+        .query(
+            app.factory_addr.clone(),
+            &oraiswap::factory::QueryMsg::Config {},
+        )
+        .unwrap();
+
+    assert_eq!(config, factory_config.operator);
 
     // should never change commission rate once deployed
     let pair_res = app.query_pair(asset_infos.clone()).unwrap();

--- a/packages/oraiswap/src/factory.rs
+++ b/packages/oraiswap/src/factory.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Decimal};
+use cosmwasm_std::{Addr, Binary};
 
 use crate::asset::{Asset, AssetInfo, PairInfo};
 
@@ -11,6 +11,7 @@ pub struct InstantiateMsg {
     pub oracle_addr: Addr,
     pub commission_rate: Option<String>,
     pub operator_fee: Option<String>,
+    pub operator: Option<String>,
 }
 
 #[cw_serde]
@@ -64,6 +65,9 @@ pub struct ConfigResponse {
     pub oracle_addr: Addr,
     pub pair_code_id: u64,
     pub token_code_id: u64,
+    pub commission_rate: String,
+    pub operator_fee: String,
+    pub operator: Addr,
 }
 
 /// We currently take no arguments for migrations
@@ -75,6 +79,7 @@ pub struct MigrateMsg {
     pub oracle_addr: Addr,
     pub commission_rate: Option<String>,
     pub operator_fee: Option<String>,
+    pub operator: Option<String>,
 }
 
 // We define a custom struct for each query response

--- a/packages/oraiswap/src/testing.rs
+++ b/packages/oraiswap/src/testing.rs
@@ -8,7 +8,7 @@ use oraiswap_v3::percentage::Percentage;
 
 use crate::pair::{DEFAULT_COMMISSION_RATE, DEFAULT_OPERATOR_FEE};
 use cosmwasm_testing_util::{
-    error::{AnyError, Error},
+    error::AnyError,
     AppResponse, Code, MockResult,
 };
 
@@ -100,6 +100,7 @@ impl MockApp {
                     oracle_addr,
                     commission_rate: Some(DEFAULT_COMMISSION_RATE.to_string()),
                     operator_fee: Some(DEFAULT_OPERATOR_FEE.to_string()),
+                    operator: None,
                 },
                 &[],
                 "factory",

--- a/packages/oraiswap/src/testing.rs
+++ b/packages/oraiswap/src/testing.rs
@@ -1,3 +1,5 @@
+use std::ops::Add;
+
 use crate::{
     asset::{Asset, AssetInfo, PairInfo, ORAI_DENOM},
     factory::ProvideLiquidityParams,
@@ -7,10 +9,7 @@ use derive_more::{Deref, DerefMut};
 use oraiswap_v3::percentage::Percentage;
 
 use crate::pair::{DEFAULT_COMMISSION_RATE, DEFAULT_OPERATOR_FEE};
-use cosmwasm_testing_util::{
-    error::AnyError,
-    AppResponse, Code, MockResult,
-};
+use cosmwasm_testing_util::{error::AnyError, AppResponse, Code, MockResult};
 
 pub const ATOM_DENOM: &str = "ibc/1777D03C5392415FE659F0E8ECB2CE553C6550542A68E4707D5D46949116790B";
 pub const APP_OWNER: &str = "admin";
@@ -100,7 +99,7 @@ impl MockApp {
                     oracle_addr,
                     commission_rate: Some(DEFAULT_COMMISSION_RATE.to_string()),
                     operator_fee: Some(DEFAULT_OPERATOR_FEE.to_string()),
-                    operator: None,
+                    operator: Some(Addr::unchecked("operator").into_string()),
                 },
                 &[],
                 "factory",


### PR DESCRIPTION
This pull request includes several changes to the `contracts/oraiswap_factory` and `packages/oraiswap` modules to add support for the `operator` field and update related functionalities. The most important changes include adding the `operator` field to various structs, updating functions to handle the new field, and modifying tests to reflect these changes.

### Changes to add and handle `operator` field:

* [`contracts/oraiswap_factory/src/contract.rs`](diffhunk://#diff-11c0896576ac0d31af646613b4214dc37a708285e64865e00b7a0abb61dceb0cR44-R46): Added the `operator` field to the `instantiate`, `execute_create_pair`, `query_config`, and `migrate` functions. [[1]](diffhunk://#diff-11c0896576ac0d31af646613b4214dc37a708285e64865e00b7a0abb61dceb0cR44-R46) [[2]](diffhunk://#diff-11c0896576ac0d31af646613b4214dc37a708285e64865e00b7a0abb61dceb0cL228-R231) [[3]](diffhunk://#diff-11c0896576ac0d31af646613b4214dc37a708285e64865e00b7a0abb61dceb0cR403-R405) [[4]](diffhunk://#diff-11c0896576ac0d31af646613b4214dc37a708285e64865e00b7a0abb61dceb0cR442) [[5]](diffhunk://#diff-11c0896576ac0d31af646613b4214dc37a708285e64865e00b7a0abb61dceb0cR452-R456)
* [`contracts/oraiswap_factory/src/state.rs`](diffhunk://#diff-2769c2771d64f39eb48e5da7f5773e4f087f574c961f5e24ae75cf28bc016285R15): Added the `operator` field to the `Config` struct and updated the test module to include the `operator` field. [[1]](diffhunk://#diff-2769c2771d64f39eb48e5da7f5773e4f087f574c961f5e24ae75cf28bc016285R15) [[2]](diffhunk://#diff-2769c2771d64f39eb48e5da7f5773e4f087f574c961f5e24ae75cf28bc016285R93)
* [`packages/oraiswap/src/factory.rs`](diffhunk://#diff-9d540b653afe2dc9279a4f69930b99d7869122b9d2d6ec5e443c83b79959fec3R14): Added the `operator` field to the `InstantiateMsg`, `ConfigResponse`, and `MigrateMsg` structs. [[1]](diffhunk://#diff-9d540b653afe2dc9279a4f69930b99d7869122b9d2d6ec5e443c83b79959fec3R14) [[2]](diffhunk://#diff-9d540b653afe2dc9279a4f69930b99d7869122b9d2d6ec5e443c83b79959fec3R68-R70) [[3]](diffhunk://#diff-9d540b653afe2dc9279a4f69930b99d7869122b9d2d6ec5e443c83b79959fec3R82)

### Updates to testing:

* [`contracts/oraiswap_factory/src/testing.rs`](diffhunk://#diff-e8aa6b849447f783e2d6a01c30ca2659348ade4010bdb8f667222987560532b2L1-R6): Updated imports and added code to query and assert the `operator` field in the `create_pair` function. [[1]](diffhunk://#diff-e8aa6b849447f783e2d6a01c30ca2659348ade4010bdb8f667222987560532b2L1-R6) [[2]](diffhunk://#diff-e8aa6b849447f783e2d6a01c30ca2659348ade4010bdb8f667222987560532b2R52-R69)
* [`packages/oraiswap/src/testing.rs`](diffhunk://#diff-438631511b2b13abd7d1c890a4e9c3a4d1e873aa799092a80f9121712f85adaaR1-R2): Added the `operator` field to the mock application setup and updated imports. [[1]](diffhunk://#diff-438631511b2b13abd7d1c890a4e9c3a4d1e873aa799092a80f9121712f85adaaR1-R2) [[2]](diffhunk://#diff-438631511b2b13abd7d1c890a4e9c3a4d1e873aa799092a80f9121712f85adaaL10-R12) [[3]](diffhunk://#diff-438631511b2b13abd7d1c890a4e9c3a4d1e873aa799092a80f9121712f85adaaR102)